### PR TITLE
Add micro instance type for notifications release

### DIFF
--- a/bosh-lite/cloud-config.yml
+++ b/bosh-lite/cloud-config.yml
@@ -8,6 +8,11 @@ vm_types:
     ephemeral_disk:
       size: 1024
       type: gp2
+- name: micro
+  cloud_properties:
+    ephemeral_disk:
+      size: 1024
+      type: gp2
 compilation:
   workers: 4
   network: default


### PR DESCRIPTION
Notifications release now expects a vm_type of "micro" in order to
deploy properly. We want to make this vm type available.

[#165552618]

Signed-off-by: Kai Xiang <kxiang@pivotal.io>